### PR TITLE
Fixed timeout crashing the client.

### DIFF
--- a/instrumentserver/client/core.py
+++ b/instrumentserver/client/core.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 class BaseClient:
     """Simple client for the StationServer.
+    When a timeout happens, a RunTimeError is being raised. This error is there just to warn the user that a timeout
+    has occurred. After that the client will restart the socket to continue the normal work.
 
     :param host: The host address of the server, defaults to localhost.
     :param port: The port of the server, defaults to the value of DEFAULT_PORT.

--- a/instrumentserver/client/core.py
+++ b/instrumentserver/client/core.py
@@ -14,9 +14,16 @@ logger = logging.getLogger(__name__)
 
 
 class BaseClient:
-    """Simple client for the StationServer"""
+    """Simple client for the StationServer.
 
-    def __init__(self, host='localhost', port=DEFAULT_PORT, connect=True):
+    :param host: The host address of the server, defaults to localhost.
+    :param port: The port of the server, defaults to the value of DEFAULT_PORT.
+    :param connect: If true, the server connects as it is being constructed, defaults to True.
+    :param timeout: Amount of time that the client waits for an answer before declaring timeout in ms.
+                    Defaults to 5000.
+    """
+
+    def __init__(self, host='localhost', port=DEFAULT_PORT, connect=True, timeout=5000):
         self.connected = False
         self.context = None
         self.socket = None
@@ -25,7 +32,7 @@ class BaseClient:
         self.addr = f"tcp://{host}:{port}"
 
         #: timeout for server replies.
-        self.recv_timeout = 5000
+        self.recv_timeout = timeout
 
         if connect:
             self.connect()
@@ -50,23 +57,32 @@ class BaseClient:
         if not self.connected:
             raise RuntimeError("No connection yet.")
 
-        send(self.socket, message)
-        ret = recv(self.socket)
-        logger.info(f"Response received.")
-        logger.debug(f"Response: {str(ret)}")
+        # try so that if timeout happens, the client remains usable
+        try:
+            send(self.socket, message)
+            ret = recv(self.socket)
+            logger.info(f"Response received.")
+            logger.debug(f"Response: {str(ret)}")
 
-        if isinstance(ret, ServerResponse):
-            err = ret.error
-            if err is not None:
-                if isinstance(err, str):
-                    logger.error(err)
-                elif isinstance(err, Warning):
-                    warnings.warn(err)
-                elif isinstance(err, Exception):
-                    raise err
-                else:
-                    raise TypeError(f'Unknown Error Type: {str(err)}')
-        return ret.message
+            if isinstance(ret, ServerResponse):
+                err = ret.error
+                if err is not None:
+                    if isinstance(err, str):
+                        logger.error(err)
+                    elif isinstance(err, Warning):
+                        warnings.warn(err)
+                    elif isinstance(err, Exception):
+                        raise err
+                    else:
+                        raise TypeError(f'Unknown Error Type: {str(err)}')
+            return ret.message
+
+        except zmq.error.Again as e:
+            # if there is a timeout, close the socket and connect again
+            self.socket.close()
+            self.connect()
+            raise RuntimeError(f'Server did not reply before timeout.')
+
 
     def disconnect(self):
         self.socket.close()

--- a/instrumentserver/testing/dummy_instruments/generic.py
+++ b/instrumentserver/testing/dummy_instruments/generic.py
@@ -2,6 +2,8 @@ from typing import List
 
 from qcodes import Instrument
 from qcodes.utils import validators
+import numpy as np
+import time
 
 
 class DummyChannel(Instrument):
@@ -39,3 +41,19 @@ class DummyInstrumentWithSubmodule(Instrument):
 
     def test_func(self, a, b, *args, c: List[int] = [10, 11], **kwargs):
         return a, b, args[0], c, kwargs['d'], self.param0()
+
+
+class DummyInstrumentTimeout(Instrument):
+    """A dummy instrument to test timeout situations"""
+    def __init__(self, name: str, *args,  **kwargs):
+        super().__init__(name, *args, **kwargs)
+
+        self.random = np.random.randint(10000)
+
+    def get_random(self):
+        return self.random
+
+    def get_random_timeout(self):
+        time.sleep(10)
+        return self.random
+


### PR DESCRIPTION
When creating a new client now you can pass timeout as a parameter in the constructor. If timeout occurs the socket now is closed and connected again. A RuntimeError is raised to warn the user of the timeout, however, the client remains usable now.

Added some basic documentation in the docstring of the BaseClient.

Created basic dummy instrument to test the timeout situation.