### PR TITLE
renaming create_instrument to find_or_create_instrument

### DIFF
--- a/client.py
+++ b/client.py
@@ -21,7 +21,7 @@ def setup_log(win: InstrumentClientMainWindow):
 
 
 def setup_pm(win: InstrumentClientMainWindow):
-    pm = win.client.create_instrument(
+    pm = win.client.find_or_create_instrument(
         'instrumentserver.params.ParameterManager',
         'pm',
     )

--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -77,7 +77,7 @@ def parameterManagerScript() -> None:
     if args.name in cli.list_instruments():
         pm = cli.get_instrument(args.name)
     else:
-        pm = cli.create_instrument(
+        pm = cli.find_or_create_instrument(
             'instrumentserver.params.ParameterManager', args.name)
         pm.fromFile()
         pm.update()

--- a/instrumentserver/client/proxy.py
+++ b/instrumentserver/client/proxy.py
@@ -352,8 +352,8 @@ class Client(BaseClient):
         msg = ServerInstruction(operation=Operation.get_existing_instruments)
         return self.ask(msg)
 
-    def create_instrument(self, instrument_class: str, name: str,
-                          *args: Any, **kwargs: Any) -> ProxyInstrumentModule:
+    def find_or_create_instrument(self, instrument_class: str, name: str,
+                                  *args: Any, **kwargs: Any) -> ProxyInstrumentModule:
         """ Create a new instrument on the server and return a proxy for the new
         instrument.
 
@@ -459,7 +459,7 @@ class SubClient(QtCore.QObject):
     #: emitted when the server broadcast either a new parameter or an update to an existing one.
     update = QtCore.Signal(str)
 
-    def __init__(self, instruments: List[str] = None, sub_host: str = 'localhost', sub_port: int = DEFAULT_PORT+1):
+    def __init__(self, instruments: List[str] = None, sub_host: str = 'localhost', sub_port: int = DEFAULT_PORT + 1):
         """
         Creates a new subscription client.
 
@@ -475,7 +475,6 @@ class SubClient(QtCore.QObject):
         self.instruments = instruments
 
         self.connected = False
-
 
     def connect(self):
         """
@@ -499,7 +498,6 @@ class SubClient(QtCore.QObject):
         self.connected = True
 
         while self.connected:
-
             message = socket.recv_multipart()
             # emits the signals already decoded so python recognizes it a string instead of bytes
             self.update.emit(message[1].decode("utf-8"))

--- a/instrumentserver/testing/create_instrument.py
+++ b/instrumentserver/testing/create_instrument.py
@@ -10,7 +10,7 @@ cli = InstrumentClient()
 if 'test' in cli.list_instruments():
     instrument = cli.get_instrument('test')
 else:
-    instrument = cli.create_instrument(
+    instrument = cli.find_or_create_instrument(
         'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentRandomNumber',
         'test')
 

--- a/test/client_workingdir/init_client.py
+++ b/test/client_workingdir/init_client.py
@@ -12,17 +12,17 @@ from instrumentserver.client import ProxyInstrument
 #%% Create all my instruments
 Instrument.close_all()
 ins_cli = Client()
-dummy_vna = ins_cli.create_instrument(
+dummy_vna = ins_cli.find_or_create_instrument(
     'instrumentserver.testing.dummy_instruments.rf.ResonatorResponse',
     'dummy_vna'
 )
 
-dummy_multichan = ins_cli.create_instrument(
+dummy_multichan = ins_cli.find_or_create_instrument(
     'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentWithSubmodule',
     'dummy_multichan',
 )
 
-pm = ins_cli.create_instrument(
+pm = ins_cli.find_or_create_instrument(
     'instrumentserver.params.ParameterManager',
     'pm',
 )

--- a/test/prototyping/server_admin.py
+++ b/test/prototyping/server_admin.py
@@ -21,17 +21,17 @@ with Client() as cli:
 #%% create vna instrument in server
 Instrument.close_all()
 ins_cli = Client()
-dummy_vna = ins_cli.create_instrument(
+dummy_vna = ins_cli.find_or_create_instrument(
     'instrumentserver.testing.dummy_instruments.rf.ResonatorResponse',
     'dummy_vna'
 )
 
-dummy_multichan = ins_cli.create_instrument(
+dummy_multichan = ins_cli.find_or_create_instrument(
     'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentWithSubmodule',
     'dummy_multichan',
 )
 
-pm = ins_cli.create_instrument(
+pm = ins_cli.find_or_create_instrument(
     'instrumentserver.params.ParameterManager',
     'pm',
 )


### PR DESCRIPTION
Renaming the create_instrument function from Client to find_or_create_instrument to more align with qcodes.