### PR TITLE
Fixing the remaining cli.find_or_create_instrumets

### DIFF
--- a/client.py
+++ b/client.py
@@ -22,8 +22,8 @@ def setup_log(win: InstrumentClientMainWindow):
 
 def setup_pm(win: InstrumentClientMainWindow):
     pm = win.client.find_or_create_instrument(
-        'instrumentserver.params.ParameterManager',
         'pm',
+        'instrumentserver.params.ParameterManager',
     )
     w = ParameterManagerGui(pm)
     win.addWidget(w, name="PM: "+pm.name)

--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -78,7 +78,7 @@ def parameterManagerScript() -> None:
         pm = cli.get_instrument(args.name)
     else:
         pm = cli.find_or_create_instrument(
-            'instrumentserver.params.ParameterManager', args.name)
+            args.name, 'instrumentserver.params.ParameterManager')
         pm.fromFile()
         pm.update()
 

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -694,7 +694,7 @@ class StationServer(QtCore.QObject):
         kwargs = dict() if spec.kwargs is None else spec.kwargs
 
         new_instrument = qc.find_or_create_instrument(
-            cls, name=spec.name, *args, **kwargs)
+            instrument_class=cls, name=spec.name, *args, **kwargs)
         if new_instrument.name not in self.station.components:
             self.station.add_component(new_instrument)
 

--- a/instrumentserver/testing/create_instrument.py
+++ b/instrumentserver/testing/create_instrument.py
@@ -11,6 +11,6 @@ if 'test' in cli.list_instruments():
     instrument = cli.get_instrument('test')
 else:
     instrument = cli.find_or_create_instrument(
-        'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentRandomNumber',
-        'test')
+        'test'
+        'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentRandomNumber',)
 

--- a/test/client_workingdir/init_client.py
+++ b/test/client_workingdir/init_client.py
@@ -13,18 +13,20 @@ from instrumentserver.client import ProxyInstrument
 Instrument.close_all()
 ins_cli = Client()
 dummy_vna = ins_cli.find_or_create_instrument(
+    'dummy_vna',
     'instrumentserver.testing.dummy_instruments.rf.ResonatorResponse',
-    'dummy_vna'
+
 )
 
 dummy_multichan = ins_cli.find_or_create_instrument(
-    'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentWithSubmodule',
     'dummy_multichan',
+    'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentWithSubmodule',
+
 )
 
 pm = ins_cli.find_or_create_instrument(
-    'instrumentserver.params.ParameterManager',
     'pm',
+    'instrumentserver.params.ParameterManager',
 )
 
 

--- a/test/prototyping/server_admin.py
+++ b/test/prototyping/server_admin.py
@@ -22,18 +22,19 @@ with Client() as cli:
 Instrument.close_all()
 ins_cli = Client()
 dummy_vna = ins_cli.find_or_create_instrument(
+    'dummy_vna',
     'instrumentserver.testing.dummy_instruments.rf.ResonatorResponse',
-    'dummy_vna'
+
 )
 
 dummy_multichan = ins_cli.find_or_create_instrument(
-    'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentWithSubmodule',
     'dummy_multichan',
+    'instrumentserver.testing.dummy_instruments.generic.DummyInstrumentWithSubmodule',
 )
 
 pm = ins_cli.find_or_create_instrument(
-    'instrumentserver.params.ParameterManager',
     'pm',
+    'instrumentserver.params.ParameterManager',
 )
 
 


### PR DESCRIPTION
Some client instrument creations slipped me. It was stopping the instrumentserver from opening the parmeter manager. It is fixed now.