### PR TITLE
Gui/adding instruments

### DIFF
--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -1,3 +1,8 @@
+"""
+If any instrument in the config does not have values for SERVERFIELDS or GUIFIELD, the values inside of it are added
+to the config as defaults. If you are adding any extra fields to the config make sure to add the default values on those
+variables since we parse the config using those.
+"""
 import io
 import tempfile
 
@@ -14,16 +19,17 @@ def loadConfig(configPath: str):
     """
     Loads the config for the instrumentserver. From 1 config file it splits the respective fields into 3 different
     objects: a serverConfig (the configurations for the server), a stationConfig(the qcodes station config file clean
-    of any extra config fields), and a GUI config file (any config that the GUI of the server needs.
+    of any extra config fields), and a GUI config file (any config that the GUI of the server needs).
 
-    The qcodes station only accepts the path of an actual file for its config. So after loading the YAML file, the added
-    fields are removed from the loaded dictionary. After that it is converted to a byte stream and written into a temporary file.
-    what is returned here is the path to that temporary file, after the station loads the file, it gets deleted automatically
+    The qcodes station only accepts the path of an actual file for its config. So after loading the YAML file,
+    the added fields are removed from the loaded dictionary. After that it is converted to a byte stream and written
+    into a temporary file. what is returned here is the path to that temporary file, after the station loads the
+    file, it gets deleted automatically
     """
     configPath = Path(configPath)
-    serverConfig = {}
-    guiConfig = {}
-    stationConfig = None
+    serverConfig = {}  # Config for the server
+    guiConfig = {}  # Individual gui config of each instrument
+    fullConfig = {}  # serverConfig + guiConfig + any unfilled fields. Used for creating instruments from the gui
 
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)
@@ -40,6 +46,8 @@ def loadConfig(configPath: str):
             else:
                 serverConfig[instrumentName][field] = default
 
+        # we don't go through the entire gui because generic is a special setting
+        # and we only have 2 different options for now
         if 'gui' in configDict:
             guiDict = configDict.pop('gui')
             if guiDict is None:
@@ -47,9 +55,15 @@ def loadConfig(configPath: str):
             if 'type' in guiDict:
                 if guiDict['type'] == 'generic' or guiDict['type'] == 'Generic':
                     guiDict['type'] = GUIFIELD['type']
+            # If the user does not specify a gui, the default one will be used
+            else:
+                guiDict['type'] = GUIFIELD['type']
+
             guiConfig[instrumentName] = guiDict
         else:
             guiConfig[instrumentName] = GUIFIELD
+
+        fullConfig[instrumentName] = {'gui': guiConfig[instrumentName], **configDict, **serverConfig[instrumentName]}
 
     # Creating the file like object
     with io.BytesIO() as ioBytesFile:
@@ -63,7 +77,7 @@ def loadConfig(configPath: str):
     tempFilePath = tempFile.name
 
     # You need to return the tempFile itself so that the garbage collector doesn't touch it
-    return tempFilePath, serverConfig, guiConfig, tempFile
+    return tempFilePath, serverConfig, fullConfig, tempFile
 
 
 

--- a/instrumentserver/gui/instruments.py
+++ b/instrumentserver/gui/instruments.py
@@ -200,10 +200,10 @@ class MethodDisplay(QtWidgets.QWidget):
             if kwargs is not None:
                 ret = self.fun(*args, **kwargs)
             else:
-                if isinstance(args, list) or isinstance(args, tuple):
+                if isinstance(args, list) or isinstance(args, tuple) or args != '':
                     ret = self.fun(*args)
                 else:
-                    ret = self.fun(args)
+                    ret = self.fun()
             self.runSuccessful.emit(str(ret))
             logger.info(f"'{self.fullName}' returned: {ret}")
 

--- a/instrumentserver/gui/misc.py
+++ b/instrumentserver/gui/misc.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple
 
-from .. import QtWidgets, QtGui, resource, QtCore
+from .. import QtWidgets, QtGui, QtCore
 
 
 class AlertLabel(QtWidgets.QLabel):
@@ -240,3 +240,23 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
         # When moving the tabs, we don't want to emit the signal since the tab is not being closed, just moved.
         if not moving:
             self.onTabClosed.emit(name)
+
+
+class BaseDialog(QtWidgets.QDialog):
+    """
+    Base dialog for internal purposes. Has correct flags so that the question mark does not appear.
+    Also overload set tittle such that the size of the window gets adjusted in a way that the tittle is not clipped.
+
+    :param tittleBarButtonsWidth: The width of pixels that the icon, the width will be set such that it is this number
+        plus whatever the tittle is plus 15 extra pixels of margin.
+    """
+    def __init__(self, parent=None, flags=(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowCloseButtonHint), tittleBarButtonsWidth=108):
+        super().__init__(parent, flags=flags)
+        self.tittleBarButtonsWidth = tittleBarButtonsWidth
+
+    def setWindowTitle(self, p_str):
+        super().setWindowTitle(p_str)
+        tittleWidth = self.fontMetrics().boundingRect(p_str).size().width()
+        minWidth = self.tittleBarButtonsWidth + tittleWidth + 15
+        if self.width() < minWidth:
+            self.resize(minWidth, self.height())

--- a/instrumentserver/server/application.py
+++ b/instrumentserver/server/application.py
@@ -14,7 +14,7 @@ from .core import (
     InstrumentModuleBluePrint, ParameterBluePrint
 )
 from .. import QtCore, QtWidgets, QtGui
-from ..gui.misc import DetachableTabWidget
+from ..gui.misc import DetachableTabWidget, BaseDialog
 from ..gui.parameters import AnyInputForMethod
 from ..gui.instruments import GenericInstrument
 
@@ -126,14 +126,15 @@ class ServerStatus(QtWidgets.QWidget):
 
 
 # TODO: Come up with a better name
-# TODO: have it such that you cannot change the vertical length of it
-class CreateInstrumentDialog(QtWidgets.QDialog):
+class CreateInstrumentDialog(BaseDialog):
 
     createInstrument = QtCore.Signal(str, str, tuple)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(flags=(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowCloseButtonHint), *args, **kwargs)
 
+        tittleText = 'Create New Instrument'
+        self.setWindowTitle(tittleText)
         layout = QtWidgets.QVBoxLayout(self)
 
         formLayout = QtWidgets.QFormLayout()
@@ -144,11 +145,11 @@ class CreateInstrumentDialog(QtWidgets.QDialog):
 
         formLayout.addRow(QtWidgets.QLabel('Instrument Type:'), self.typeEdit)
         formLayout.addRow(QtWidgets.QLabel('Instrument Name:'), self.nameEdit)
-        formLayout.addRow(QtWidgets.QLabel('arguments and keyword arguments:'), self.argsEdit)
+        formLayout.addRow(QtWidgets.QLabel('Args and Kwargs:'), self.argsEdit)
 
         layout.addLayout(formLayout)
 
-        self.acceptButton = QtWidgets.QPushButton("Create baby create")
+        self.acceptButton = QtWidgets.QPushButton("Create")
         self.acceptButton.setDefault(True)
         buttonSizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Maximum)
         self.acceptButton.setSizePolicy(buttonSizePolicy)
@@ -170,7 +171,7 @@ class CreateInstrumentDialog(QtWidgets.QDialog):
         """
         Opens another dialog indicating the problem with the creation of the instrument
         """
-        dialog = QtWidgets.QDialog(parent=self)
+        dialog = BaseDialog(parent=self)
         dialog.setWindowTitle("Instrument Creation Error")
         layout = QtWidgets.QVBoxLayout(dialog)
 

--- a/instrumentserver/server/application.py
+++ b/instrumentserver/server/application.py
@@ -600,6 +600,9 @@ class ServerGui(QtWidgets.QMainWindow):
         """Remove an instrument from the station list."""
         self.stationList.removeObject(name)
         del self._bluePrints[name]
+        if name in self.instrumentTabsOpen:
+            self.tabs.removeTab(self.tabs.indexOf(self.instrumentTabsOpen[name]))
+            del self.instrumentTabsOpen[name]
 
     def refreshStationComponents(self):
         """Clear and re-populate the widget holding the station components, using

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -74,8 +74,8 @@ class StationServer(QtCore.QObject):
     finished = QtCore.Signal()
 
     #: Signal(Dict) -- emitted when a new instrument was created.
-    #: Argument is the blueprint of the instrument.
-    instrumentCreated = QtCore.Signal(object)
+    #: Argument is the blueprint of the instrument, the args and kwargs used to create it.
+    instrumentCreated = QtCore.Signal(object, object, dict)
 
     #: Signal(str, Any) -- emitted when a parameter was set
     #: Arguments: full parameter location as string, value.
@@ -308,10 +308,8 @@ class StationServer(QtCore.QObject):
         if new_instrument.name not in self.station.components:
             self.station.add_component(new_instrument)
 
-            self.instrumentCreated.emit(
-                bluePrintFromInstrumentModule(new_instrument.name,
-                                              new_instrument)
-            )
+            self.instrumentCreated.emit(bluePrintFromInstrumentModule(new_instrument.name, new_instrument),
+                                        args, kwargs)
 
     def _callObject(self, spec: CallSpec) -> Any:
         """Call some callable found in the station."""

--- a/instrumentserver/testing/dummy_instruments/generic.py
+++ b/instrumentserver/testing/dummy_instruments/generic.py
@@ -29,11 +29,16 @@ class DummyChannel(Instrument):
         print(f'kwargs: {kwargs}')
         return True
 
+
 class DummyInstrumentWithSubmodule(Instrument):
     """A dummy instrument with submodules."""
 
-    def __init__(self, name: str, *args, **kwargs):
+    def __init__(self, name: str, address=None, first_arg=None, second_arg=None, *args, **kwargs):
         super().__init__(name, *args, **kwargs)
+        self.address = address
+
+        self.first_arg = first_arg
+        self.second_arg = second_arg
 
         self.add_parameter('param0',
                            set_cmd=None,
@@ -69,7 +74,7 @@ class DummyInstrumentWithSubmodule(Instrument):
         print(f'the dummy chanel: {self.name} has been activated with:')
         print(f'args: {args}')
         print(f'kwargs: {kwargs}')
-        return "I am being returned"
+        return self.address, self.first_arg, self.second_arg
 
 
 class DummyInstrumentTimeout(Instrument):

--- a/instrumentserver/testing/dummy_instruments/generic.py
+++ b/instrumentserver/testing/dummy_instruments/generic.py
@@ -145,13 +145,13 @@ class FieldVectorIns(Instrument):
     """
     class used to develop json serialization and guis
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, name, starting_parameter=22, *args, **kwargs):
+        super().__init__(name=name, *args, **kwargs)
 
         self.field_vector = FieldVector(x=1, y=1, z=1)
         self.complex_value = 1 + 1j
-
         self.complex_lst = [1 + 1j, -2 - 2j]
+        self.starting_parameter = starting_parameter
 
         self.add_parameter(name="field",
                            label='target field',
@@ -173,6 +173,12 @@ class FieldVectorIns(Instrument):
                            get_cmd=self.get_complex_list,
                            set_cmd=self.set_complex_list,
                            )
+
+    def get_starting_parameter(self):
+        return self.starting_parameter
+
+    def set_starting_parameter(self, new_value):
+        pass
 
     def get_field(self):
         return self.field_vector


### PR DESCRIPTION
An instrument creator to the station display of the server has been added. These new creator allows you to create new instruments through a dialog and it also displays a tree with possible instruments. The possible instruments are all the instruments from the config file as well as any other instrument the user creates through the client. When the user creates a new instrument through a client, the args and kwargs get saved and are used as presets for the next instrument. You can also close instruments by right clicking in the instrument station list or use the shortcut 'del' or 'backspace'.