### PR TITLE
The server GUI could not open on a mac

### DIFF
--- a/instrumentserver/gui/misc.py
+++ b/instrumentserver/gui/misc.py
@@ -184,7 +184,11 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
 
     def addUnclosableTab(self, widget, name):
         index = self.addTab(widget, name)
-        self._tabBar.tabButton(index, QtWidgets.QTabBar.ButtonPosition.RightSide).resize(0, 0)
+        closeButton = self._tabBar.tabButton(index, QtWidgets.QTabBar.ButtonPosition.RightSide)
+        # on Mac the button is on the left side
+        if closeButton is None:
+            closeButton = self._tabBar.tabButton(index, QtWidgets.QTabBar.ButtonPosition.LeftSide)
+        closeButton.resize(0, 0)
         self.unclosableTabs[name] = widget
 
     @QtCore.Slot(object, object)


### PR DESCRIPTION
Because the close tab button in mac is in the left side, when trying to remove the unclosable tabs the button did not exist.