### PR TITLE
Adding profiles to the parameter manager (non UI).

### DIFF
--- a/instrumentserver/gui/base_instrument.py
+++ b/instrumentserver/gui/base_instrument.py
@@ -2,7 +2,7 @@
 Quick Introduction
 ==================
 
-This module contains the all the base classes necessaries to display different properties dictionaries of instruments.
+This module contains all the base classes necessaries to display different properties dictionaries of instruments.
 The goal is to have a base design such that implementing further GUIS is simplified and can be done without repeating
 much code. To implement your own GUI you just need to inherit any particular part you want to customize.
 
@@ -59,7 +59,7 @@ Things to pay attention when implementing your own:
 InstrumentSortFilterProxyModel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This class is in charge of filtering and sorting of the model. For most things you should not have to care about this
+This class is in charge of filtering and sorting of the model. For most things, you should not have to care about this
 class.
 
 It might be helpful to know, before a new filtering happens, the proxy model emits the signal filterIncoming,
@@ -70,12 +70,12 @@ InstrumentTreeViewBase
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The view is in charge of displaying the model data. It uses the ProxyModel to filter and sort the items for it. The
-main thing you need to implement for this class is its delegate. Delegates are classes in charge of create the
+main thing you need to implement for this class is its delegate. Delegates are classes in charge of creating the
 widgets that are shown for each row of the view. Usually they are the way we represent the information we want to
 show and allows us to interact with it.
 
 When creating your own delegate, you need to inherit from the class QStyledItemDelegate.
-Other than the constructor the only class that your delegate should have implemented is the createEditor class.
+Other than the constructor, the only class that your delegate should have implemented is the createEditor class.
 This class is responsible to return an already created widget for a specific item.
 If any signal needs to be connected from or to this widget, it should happen in the createEditor function.
 
@@ -91,14 +91,14 @@ InstrumentDisplayBase
 ^^^^^^^^^^^^^^^^^^^^^
 
 This is the class that brings everything together. It is the widget that should be added to a layout.
-When calling the constructor you can pass any of the 4 previous classes to it to utilize your version of it, instead
+When calling the constructor, you can pass any of the 4 previous classes to it to utilize your version of it, instead
 of the base one.
 
 All items connect their own signals with their own slots, but if any class needs to connect to a slot of a different
 class, that happens in the connectSignal method If you need to implement any of your own signals, override this
 method and after calling the super version of it, connect your signals.
 
-To add more items to the toolbar for any extra functionality you can do so by overriding the makeToolbar method.
+To add more items to the toolbar for any extra functionality, you can do so by overriding the makeToolbar method.
 
 """
 

--- a/instrumentserver/gui/instruments.py
+++ b/instrumentserver/gui/instruments.py
@@ -406,40 +406,6 @@ class ParameterManagerTreeView(InstrumentTreeViewBase):
         widget.paramWidget.setValue(value)
 
 
-class ProfileManager(QtWidgets.QWidget):
-
-    def __init__(self,
-                 parent: Optional[QtWidgets.QWidget] = None,
-                 flags: Union[QtCore.Qt.WindowFlags, QtCore.Qt.WindowType] = QtCore.Qt.WindowFlags()
-                 ):
-        super().__init__(parent, flags)
-
-        self.layout_ = QtWidgets.QHBoxLayout()
-
-        self.comboBox = QtWidgets.QComboBox(self)
-        self.addButton = QtWidgets.QPushButton(QtGui.QIcon(":/icons/plus-square.svg"), "add",)
-        self.deleteButton = QtWidgets.QPushButton(QtGui.QIcon(":/icons/delete.svg"), "delete",)
-
-        self.deleteButton.setStyleSheet("""
-            QPushButton {background-color: salmon;}
-        """)
-
-        self.deleteButton.setFixedWidth(self.addButton.sizeHint().width())
-        self.deleteButton.setFixedHeight(self.addButton.sizeHint().height())
-
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Minimum)
-        self.addButton.setSizePolicy(sizePolicy)
-        self.deleteButton.setSizePolicy(sizePolicy)
-
-        self.comboBox.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
-
-        self.layout_.addWidget(self.addButton, stretch=0)
-        self.layout_.addWidget(self.deleteButton, stretch=0)
-        self.layout_.addWidget(self.comboBox)
-
-        self.setLayout(self.layout_)
-
-
 class ParameterManagerGui(InstrumentParameters):
     #: Signal(str) --
     #: emitted when there's an error during parameter creation.
@@ -451,10 +417,7 @@ class ParameterManagerGui(InstrumentParameters):
 
     def __init__(self, instrument: Union[ProxyInstrument, ParameterManager], **kwargs):
         super().__init__(instrument, viewType=ParameterManagerTreeView, callSignals=False, **kwargs)
-
-        self.profileManager = ProfileManager(parent=self)
         self.addParam = AddParameterWidget(parent=self)
-        self.layout().insertWidget(0, self.profileManager)
         self.layout().addWidget(self.addParam)
         self.connectSignals()
 

--- a/instrumentserver/gui/instruments.py
+++ b/instrumentserver/gui/instruments.py
@@ -406,6 +406,40 @@ class ParameterManagerTreeView(InstrumentTreeViewBase):
         widget.paramWidget.setValue(value)
 
 
+class ProfileManager(QtWidgets.QWidget):
+
+    def __init__(self,
+                 parent: Optional[QtWidgets.QWidget] = None,
+                 flags: Union[QtCore.Qt.WindowFlags, QtCore.Qt.WindowType] = QtCore.Qt.WindowFlags()
+                 ):
+        super().__init__(parent, flags)
+
+        self.layout_ = QtWidgets.QHBoxLayout()
+
+        self.comboBox = QtWidgets.QComboBox(self)
+        self.addButton = QtWidgets.QPushButton(QtGui.QIcon(":/icons/plus-square.svg"), "add",)
+        self.deleteButton = QtWidgets.QPushButton(QtGui.QIcon(":/icons/delete.svg"), "delete",)
+
+        self.deleteButton.setStyleSheet("""
+            QPushButton {background-color: salmon;}
+        """)
+
+        self.deleteButton.setFixedWidth(self.addButton.sizeHint().width())
+        self.deleteButton.setFixedHeight(self.addButton.sizeHint().height())
+
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Minimum)
+        self.addButton.setSizePolicy(sizePolicy)
+        self.deleteButton.setSizePolicy(sizePolicy)
+
+        self.comboBox.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+
+        self.layout_.addWidget(self.addButton, stretch=0)
+        self.layout_.addWidget(self.deleteButton, stretch=0)
+        self.layout_.addWidget(self.comboBox)
+
+        self.setLayout(self.layout_)
+
+
 class ParameterManagerGui(InstrumentParameters):
     #: Signal(str) --
     #: emitted when there's an error during parameter creation.
@@ -417,7 +451,10 @@ class ParameterManagerGui(InstrumentParameters):
 
     def __init__(self, instrument: Union[ProxyInstrument, ParameterManager], **kwargs):
         super().__init__(instrument, viewType=ParameterManagerTreeView, callSignals=False, **kwargs)
+
+        self.profileManager = ProfileManager(parent=self)
         self.addParam = AddParameterWidget(parent=self)
+        self.layout().insertWidget(0, self.profileManager)
         self.layout().addWidget(self.addParam)
         self.connectSignals()
 

--- a/instrumentserver/params.py
+++ b/instrumentserver/params.py
@@ -86,7 +86,7 @@ class ParameterManager(InstrumentBase):
         self._workingDirectory = Path(os.getcwd())
 
         #: default location and name of the parameters save file.
-        self.selectedProfile = self.name
+        self.selectedProfile = self.fullProfileName(self.name)
         self.profiles = []
 
         self.fromFile()
@@ -315,7 +315,7 @@ class ParameterManager(InstrumentBase):
 
             if filePath.name.startswith("parameter_manager-") and filePath.name.endswith(".json"):
                 path = Path(filePath)
-                profileName = self.cleanProfileName(path.name)
+                profileName = path.name
                 self.selectedProfile = profileName
                 if path.name not in self.profiles:
                     self.profiles.append(profileName)
@@ -387,7 +387,7 @@ class ParameterManager(InstrumentBase):
         if os.path.isdir(filePath):
             if name is None:
                 name = self.selectedProfile
-            filePath = os.path.join(filePath, f"parameter_manager-{name}.json")
+            filePath = os.path.join(filePath,  self.fullProfileName(name))
 
         folder, file = os.path.split(filePath)
         params = self.toParamDict()
@@ -398,7 +398,7 @@ class ParameterManager(InstrumentBase):
 
         file = str(file)
         if file.startswith("parameter_manager-") and file.endswith(".json"):
-            self.selectedProfile = self.cleanProfileName(file)
+            self.selectedProfile = file
 
     def switch_to_profile(self, profile: str):
         """
@@ -407,7 +407,7 @@ class ParameterManager(InstrumentBase):
         if not self.does_profile_exist(self.profiles, profile):
             raise ValueError(f"Profile {profile} does not exist")
 
-        self.toFile(str(self.workingDirectory), self.cleanProfileName(str(self.selectedProfile)))
+        self.toFile(str(self.workingDirectory), self.selectedProfile)
         self.remove_all_parameters()
         self.fromFile(str(self.workingDirectory.joinpath(self.fullProfileName(profile))))
         self.selectedProfile = self.fullProfileName(profile)

--- a/instrumentserver/params.py
+++ b/instrumentserver/params.py
@@ -86,8 +86,7 @@ class ParameterManager(InstrumentBase):
         self._workingDirectory = Path(os.getcwd())
 
         #: default location and name of the parameters save file.
-        self.defaultProfile = f'parameter_manager-{self.name}.json'
-        self.selectedProfile = self.defaultProfile
+        self.selectedProfile = self.name
         self.profiles = []
 
         self.fromFile()
@@ -305,7 +304,7 @@ class ParameterManager(InstrumentBase):
             ParameterManager that are not listed in the file.
         """
         if filePath is None:
-            filePath = self.defaultProfile
+            filePath = self.workingDirectory.joinpath(self.fullProfileName(self.selectedProfile))
 
         if os.path.exists(filePath):
             with open(filePath, 'r') as f:
@@ -316,9 +315,10 @@ class ParameterManager(InstrumentBase):
 
             if filePath.name.startswith("parameter_manager-") and filePath.name.endswith(".json"):
                 path = Path(filePath)
-                self.selectedProfile = path.name
+                profileName = self.cleanProfileName(path.name)
+                self.selectedProfile = profileName
                 if path.name not in self.profiles:
-                    self.profiles.append(path.name)
+                    self.profiles.append(profileName)
 
         else:
             logger.warning("parameter file not found, cannot load.")
@@ -386,7 +386,7 @@ class ParameterManager(InstrumentBase):
 
         if os.path.isdir(filePath):
             if name is None:
-                name = self.name
+                name = self.selectedProfile
             filePath = os.path.join(filePath, f"parameter_manager-{name}.json")
 
         folder, file = os.path.split(filePath)
@@ -398,7 +398,7 @@ class ParameterManager(InstrumentBase):
 
         file = str(file)
         if file.startswith("parameter_manager-") and file.endswith(".json"):
-            self.selectedProfile = file
+            self.selectedProfile = self.cleanProfileName(file)
 
     def switch_to_profile(self, profile: str):
         """

--- a/test/pytest/test_param_manager.py
+++ b/test/pytest/test_param_manager.py
@@ -58,6 +58,46 @@ def test_finding_all_profiles(tmp_path):
                                        'parameter_manager-fourth.json'])
 
 
+def test_saving_correct_profile(tmp_path):
+
+    params = ParameterManager(name='params')
+    params.workingDirectory = tmp_path
+
+    prep_param_manager(params)
+    params.toFile(name='first')
+    file_path = tmp_path.joinpath('parameter_manager-first.json')
+    assert file_path.exists()
+
+    params.my_param(8888)
+    params.toFile()
+
+    with open(file_path) as file:
+        data = json.load(file)
+
+    assert data['params.my_param']['value'] == 8888
+
+
+def test_loading_correct_profile(tmp_path):
+
+    params = ParameterManager(name='params')
+    params.workingDirectory = tmp_path
+
+    prep_param_manager(params)
+    params.toFile(name='first')
+    file_path = tmp_path.joinpath('parameter_manager-first.json')
+
+    with open(file_path) as file:
+        data = json.load(file)
+
+    data['params.my_param']['value'] = 9999
+
+    with open(file_path, 'w') as file:
+        json.dump(data, file)
+
+    params.fromFile()
+    assert params.my_param() == 9999
+
+
 def prep_switching_profiles(tmp_path):
     params = ParameterManager(name='params')
 

--- a/test/pytest/test_param_manager.py
+++ b/test/pytest/test_param_manager.py
@@ -1,0 +1,142 @@
+import json
+
+from instrumentserver.params import ParameterManager
+
+
+def prep_param_manager(params, template=1):
+    if template == 1:
+        params.add_parameter(name='my_param', initial_value=123, unit='M')
+        params.add_parameter(name='nested_param.child1', initial_value=456, unit='a')
+        params.add_parameter(name='nested_param.child2', initial_value=789, unit='b')
+    elif template == 2:
+        params.add_parameter(name='his_param', initial_value=-123, unit='n')
+        params.add_parameter(name='nested_param.son1', initial_value=-456, unit='c')
+        params.add_parameter(name='nested_param.son2', initial_value=-789, unit='d')
+    elif template == 3:
+        params.add_parameter(name='her_param', initial_value=0, unit='p')
+        params.add_parameter(name='nested_param.daughter1', initial_value=1, unit='e')
+        params.add_parameter(name='nested_param.daughter2', initial_value=2, unit='f')
+    elif template == 4:
+        params.add_parameter(name='our_param', initial_value=3, unit='m')
+        params.add_parameter(name='nested_param.sibling1', initial_value=[4, 6], unit='g')
+        params.nested_param.sibling1(1234856834)
+        params.add_parameter(name='nested_param.sibling2', initial_value=[5, 7], unit='h')
+
+
+def test_param(param_manager):
+    cli, params = param_manager
+
+    params.add_parameter(name='my_param', initial_value=123, unit='M')
+    assert params.my_param() == 123
+    assert params.my_param.unit == 'M'
+
+    params.my_param(456)
+    assert params.my_param() == 456
+
+
+def test_finding_all_profiles(tmp_path):
+    params = ParameterManager(name='params')
+
+    prep_param_manager(params)
+    params.toFile(tmp_path, 'first')
+
+    prep_param_manager(params, template=2)
+    params.toFile(tmp_path, 'second')
+
+    prep_param_manager(params, template=3)
+    params.toFile(tmp_path, 'third')
+
+    prep_param_manager(params, template=4)
+    params.toFile(tmp_path, 'fourth')
+
+    params.workingDirectory = tmp_path
+    profiles = params.refresh_profiles()
+
+    assert sorted(profiles) == sorted(['parameter_manager-first.json',
+                                       'parameter_manager-second.json',
+                                       'parameter_manager-third.json',
+                                       'parameter_manager-fourth.json'])
+
+
+def prep_switching_profiles(tmp_path):
+    params = ParameterManager(name='params')
+
+    prep_param_manager(params)
+    params.toFile(tmp_path, 'first')
+
+    params.remove_all_parameters()
+
+    prep_param_manager(params, template=2)
+    params.toFile(tmp_path, 'second')
+
+    params.workingDirectory = tmp_path
+    params.refresh_profiles()
+
+    return params
+
+
+def test_switching_profiles(tmp_path):
+
+    params = prep_switching_profiles(tmp_path)
+
+    params.switch_to_profile('parameter_manager-first.json')
+
+    assert params.my_param() == 123
+    assert params.nested_param.child1() == 456
+    assert params.nested_param.child2() == 789
+
+
+def test_switching_profiles_short_name(tmp_path):
+    params = prep_switching_profiles(tmp_path)
+
+    params.switch_to_profile('first')
+
+    assert params.my_param() == 123
+    assert params.nested_param.child1() == 456
+    assert params.nested_param.child2() == 789
+
+    params.switch_to_profile('second')
+
+    assert params.his_param() == -123
+    assert params.nested_param.son1() == -456
+    assert params.nested_param.son2() == -789
+
+
+def test_switching_profiles_automatic_save(tmp_path):
+    params = prep_switching_profiles(tmp_path)
+
+    params.his_param(111)
+    params.nested_param.son1(222)
+    params.nested_param.son2(333)
+
+    params.switch_to_profile('first')
+
+    # Open the JSON file
+    with open(tmp_path.joinpath('parameter_manager-second.json')) as file:
+        # Load the JSON data
+        second = json.load(file)
+
+    assert second['params.his_param']['value'] == 111
+    assert second['params.nested_param.son1']['value'] == 222
+    assert second['params.nested_param.son2']['value'] == 333
+
+
+def test_selectedProfile_only_changing_when_correct_name(tmp_path):
+    params = ParameterManager(name='params')
+
+    prep_param_manager(params)
+    names_path = tmp_path.joinpath('names.json')
+    params.toFile(names_path)
+
+    assert params.selectedProfile == 'parameter_manager-params.json'
+
+    params.fromFile(names_path)
+    assert params.selectedProfile == 'parameter_manager-params.json'
+
+    params.toFile(tmp_path, 'params')
+    assert params.selectedProfile == 'parameter_manager-params.json'
+
+    new_path = names_path.replace(tmp_path.joinpath('parameter_manager-names.json'))
+    params.fromFile(new_path)
+    assert params.selectedProfile == 'parameter_manager-names.json'
+


### PR DESCRIPTION
The parameter manager now has profiles. The basic rule is that a profile is a json file that starts with the string 'parameter_manager-' with the remainder of the filename being the actual profile name. When the user loads or saves a file that follows the convention, the profile is automatically changed.

No UI changes have been made yet, those will come in a further PR