### PR TITLE
I added a new class pollingWorker in a new thread that prints values of parameters to the terminal at rates specified in the config file

### DIFF
--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -61,15 +61,15 @@ def serverScript() -> None:
 
     stationConfig, serverConfig, guiConfig, tempFile, pollingRates = None, None, None, None, None
     if configPath != '':
-        # Separates the corresponding settings into the 4 necessary parts
+        # Separates the corresponding settings into the 5 necessary parts
         stationConfig, serverConfig, guiConfig, tempFile, pollingRates = loadConfig(configPath)
 
-    serverScript.pollingThread = QtCore.QThread()
+    pollingThread = QtCore.QThread()
     pollWorker = PollingWorker()
     pollWorker.setPollingDict(pollingRates)
-    pollWorker.moveToThread(serverScript.pollingThread)
-    serverScript.pollingThread.started.connect(pollWorker.run)
-    serverScript.pollingThread.start()
+    pollWorker.moveToThread(pollingThread)
+    pollingThread.started.connect(pollWorker.run)
+    pollingThread.start()
 
     if args.gui == 'False':
         server(port=args.port,
@@ -77,23 +77,22 @@ def serverScript() -> None:
                addresses=args.listen_at,
                initScript=args.init_script,
                serverConfig=serverConfig,
-               stationConfig=stationConfig)
+               stationConfig=stationConfig,
+               pthread = pollingThread)
     else:
         serverWithGui(port=args.port,
                       addresses=args.listen_at,
                       initScript=args.init_script,
                       serverConfig=serverConfig,
                       stationConfig=stationConfig,
-                      guiConfig=guiConfig)
+                      guiConfig=guiConfig,
+                      pthread = pollingThread)
 
     # Close and delete the temporary files
     if tempFile is not None:
         tempFile.close()
         Path(stationConfig).unlink(missing_ok=True)
 
-def _quitPollingThread():
-    serverScript.pollingThread.quit()
-    logger.info("Polling thread finished.")
 
 def parameterManagerScript() -> None:
     parser = argparse.ArgumentParser(description='Starting a parameter manager instrument GUI')

--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -91,7 +91,7 @@ def serverScript() -> None:
         tempFile.close()
         Path(stationConfig).unlink(missing_ok=True)
 
-def quitPollingThread():
+def _quitPollingThread():
     serverScript.pollingThread.quit()
     logger.info("Polling thread finished.")
 

--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -19,7 +19,8 @@ from typing import Dict
 from .client import Client
 from .gui import widgetDialog, widgetMainWindow
 from .gui.instruments import ParameterManagerGui
-from .server.pollingWorker import pollingWorker
+from .server.pollingWorker import PollingWorker
+
 setupLogging(addStreamHandler=True,
              logFile=os.path.abspath('instrumentserver.log'))
 logger = logging.getLogger('instrumentserver')
@@ -64,7 +65,7 @@ def serverScript() -> None:
         stationConfig, serverConfig, guiConfig, tempFile, pollingRates = loadConfig(configPath)
 
     serverScript.pollingThread = QtCore.QThread()
-    pollWorker = pollingWorker()
+    pollWorker = PollingWorker()
     pollWorker.setPollingDict(pollingRates)
     pollWorker.moveToThread(serverScript.pollingThread)
     serverScript.pollingThread.started.connect(pollWorker.run)
@@ -92,7 +93,7 @@ def serverScript() -> None:
 
 def quitPollingThread():
     serverScript.pollingThread.quit()
-    logger.info("Polling thread finished")
+    logger.info("Polling thread finished.")
 
 def parameterManagerScript() -> None:
     parser = argparse.ArgumentParser(description='Starting a parameter manager instrument GUI')

--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -68,9 +68,7 @@ def serverScript() -> None:
     pollWorker.setPollingDict(pollingRates)
     pollWorker.moveToThread(serverScript.pollingThread)
     serverScript.pollingThread.started.connect(pollWorker.run)
-    
     serverScript.pollingThread.start()
-
 
     if args.gui == 'False':
         server(port=args.port,

--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -32,8 +32,7 @@ def loadConfig(configPath: str):
     serverConfig = {}  # Config for the server
     guiConfig = {}  # Individual gui config of each instrument
     fullConfig = {}  # serverConfig + guiConfig + any unfilled fields. Used for creating instruments from the gui
-
-    pollingRates = {}
+    pollingRates = {} #polling rates for each parameter
 
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)

--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -9,8 +9,6 @@ import tempfile
 import ruamel.yaml
 from pathlib import Path
 
-from .client import Client
-
 # Centralised point of extra fields for the server with its default as value
 SERVERFIELDS = {'initialize': True}
 
@@ -32,7 +30,7 @@ def loadConfig(configPath: str):
     serverConfig = {}  # Config for the server
     guiConfig = {}  # Individual gui config of each instrument
     fullConfig = {}  # serverConfig + guiConfig + any unfilled fields. Used for creating instruments from the gui
-    pollingRates = {} #polling rates for each parameter
+    pollingRates = {} # Polling rates for each parameter
 
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)

--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -66,7 +66,7 @@ def loadConfig(configPath: str):
 
         if 'pollingRate' in configDict:
             pollingRateList = configDict.pop('pollingRate')
-            if pollingRateList != None:
+            if pollingRateList is not None:
                 for paramPollingRate in pollingRateList.items():
                     pollingRates.update({(instrumentName + "." + paramPollingRate[0]): paramPollingRate[1]})
 

--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -9,6 +9,8 @@ import tempfile
 import ruamel.yaml
 from pathlib import Path
 
+from .client import Client
+
 # Centralised point of extra fields for the server with its default as value
 SERVERFIELDS = {'initialize': True}
 
@@ -30,6 +32,8 @@ def loadConfig(configPath: str):
     serverConfig = {}  # Config for the server
     guiConfig = {}  # Individual gui config of each instrument
     fullConfig = {}  # serverConfig + guiConfig + any unfilled fields. Used for creating instruments from the gui
+
+    pollingRates = {}
 
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)
@@ -63,6 +67,12 @@ def loadConfig(configPath: str):
         else:
             guiConfig[instrumentName] = GUIFIELD
 
+        if 'pollingRate' in configDict:
+            pollingRateList = configDict.pop('pollingRate')
+            if pollingRateList != None:
+                for paramPollingRate in pollingRateList.items():
+                    pollingRates.update({(instrumentName + "." + paramPollingRate[0]): paramPollingRate[1]})
+
         fullConfig[instrumentName] = {'gui': guiConfig[instrumentName], **configDict, **serverConfig[instrumentName]}
 
     # Creating the file like object
@@ -77,7 +87,7 @@ def loadConfig(configPath: str):
     tempFilePath = tempFile.name
 
     # You need to return the tempFile itself so that the garbage collector doesn't touch it
-    return tempFilePath, serverConfig, fullConfig, tempFile
+    return tempFilePath, serverConfig, fullConfig, tempFile, pollingRates
 
 
 

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -233,7 +233,7 @@ class StationServer(QtCore.QObject):
             send(socket, response_to_client)
 
             self.messageReceived.emit(str(message), response_log)
-
+        # Importing at the top of the file causes a circular import
         from ..apps import quitPollingThread
         quitPollingThread()
         

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -97,7 +97,7 @@ class StationServer(QtCore.QObject):
                  initScript: Optional[str] = None,
                  serverConfig: Optional[Dict[str, Any]] = None,
                  stationConfig: Optional[str] = None,
-                 pthread: Any = None
+                 pollingThread: Any = None
                  ) -> None:
         super().__init__(parent)
 
@@ -137,8 +137,8 @@ class StationServer(QtCore.QObject):
                                                   f"kwargs: {str(kw)})'.")
         )
 
-        self.pollingThread = pthread
-        
+        self.pollingThread = pollingThread
+
 
     def _runInitScript(self):
         if os.path.exists(self.initScript):

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -234,8 +234,8 @@ class StationServer(QtCore.QObject):
 
             self.messageReceived.emit(str(message), response_log)
         # Importing at the top of the file causes a circular import
-        from ..apps import quitPollingThread
-        quitPollingThread()
+        from ..apps import _quitPollingThread
+        _quitPollingThread()
         
         self.broadcastSocket.close()
         socket.close()

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -234,6 +234,9 @@ class StationServer(QtCore.QObject):
 
             self.messageReceived.emit(str(message), response_log)
 
+        from ..apps import quitPollingThread
+        quitPollingThread()
+        
         self.broadcastSocket.close()
         socket.close()
         self.finished.emit()

--- a/instrumentserver/server/pollingWorker.py
+++ b/instrumentserver/server/pollingWorker.py
@@ -1,0 +1,41 @@
+import logging
+from .. import QtCore
+from PyQt5.QtCore import QTimer
+from ..client import Client
+
+logger = logging.getLogger(__name__)
+
+class pollingWorker(QtCore.QThread):
+    def __init__(self):
+        super().__init__(None)
+        self.cli = Client()
+        self.pollingRatesDict = {}
+
+    #used by the qtimers, get value of the param
+    def getParamValue(self, paramName):
+        logger.info(f"{paramName} currently has value {self.cli.getParamDict(paramName.split(".")[0]).get(paramName)}")
+
+    #used by apps.py, passes the list of params with their respective polling rates
+    def setPollingDict(self, pollingDict):
+        self.pollingRatesDict = pollingDict
+
+    #creates a qtimer for each param in the dict with the interval specified
+    def run(self):
+        timers = []
+
+        #deletes param from dict if it does not exist
+        delList = []
+        for param in self.pollingRatesDict:
+            if param not in self.cli.getParamDict(param.split(".")[0]):
+                logger.warn(f"Parameter {param} does not exist")
+                delList.append(param)
+        for item in delList:
+            del self.pollingRatesDict[item]
+        
+        #creates timers for each param in the dict
+        for param in self.pollingRatesDict:
+            timer = QTimer()
+            timer.timeout.connect(lambda name=param: self.getParamValue(name))
+            timer.start(self.pollingRatesDict.get(param)*1000)
+            timers.append(timer)
+        self.exec_()

--- a/instrumentserver/server/pollingWorker.py
+++ b/instrumentserver/server/pollingWorker.py
@@ -1,29 +1,28 @@
 import logging
 from .. import QtCore
-from PyQt5.QtCore import QTimer
 from ..client import Client
 
 logger = logging.getLogger(__name__)
 
-class pollingWorker(QtCore.QThread):
+class PollingWorker(QtCore.QThread):
     def __init__(self):
         super().__init__(None)
         self.cli = Client()
         self.pollingRatesDict = {}
 
-    #used by the qtimers, get value of the param
+    # Used by the qtimers, get value of the param
     def getParamValue(self, paramName):
-        logger.info(f"{paramName} currently has value {self.cli.getParamDict(paramName.split(".")[0]).get(paramName)}")
+        logger.info(f"{paramName} currently has value {self.cli.getParamDict(paramName.split('.')[0]).get(paramName)}.")
 
-    #used by apps.py, passes the list of params with their respective polling rates
+    # Used by apps.py, passes the list of params with their respective polling rates
     def setPollingDict(self, pollingDict):
         self.pollingRatesDict = pollingDict
 
-    #creates a qtimer for each param in the dict with the interval specified
+    # Creates a qtimer for each param in the dict with the interval specified
     def run(self):
         timers = []
 
-        #deletes param from dict if it does not exist
+        # Deletes param from dict if it does not exist
         delList = []
         for param in self.pollingRatesDict:
             if param not in self.cli.getParamDict(param.split(".")[0]):
@@ -32,9 +31,9 @@ class pollingWorker(QtCore.QThread):
         for item in delList:
             del self.pollingRatesDict[item]
         
-        #creates timers for each param in the dict
+        # Creates timers for each param in the dict
         for param in self.pollingRatesDict:
-            timer = QTimer()
+            timer = QtCore.QTimer()
             timer.timeout.connect(lambda name=param: self.getParamValue(name))
             timer.start(self.pollingRatesDict.get(param)*1000)
             timers.append(timer)


### PR DESCRIPTION
new file created "pollingWorker.py".
[serverConfigExample.txt](https://github.com/toolsforexperiments/instrumentserver/files/14729180/serverConfigExample.txt)
The example config file demonstrates how to use the worker. Adding the pollingRates field will create a new Qtimer for each parameter with the specified interval in the config file (in seconds). Timers will only be created for existing parameters when the server is started. Adding new parameters in the parameter manager will not create new timers. The worker runs in a new Qthread "pollingThread" created in apps.py. The thread is stopped when the server is stopped in core.py.