### PR TITLE
Added functionality for networking field in config file

### DIFF
--- a/instrumentserver/apps.py
+++ b/instrumentserver/apps.py
@@ -58,11 +58,10 @@ def serverScript() -> None:
     # Load and process the config file if any.
     configPath = args.config
 
-    stationConfig, serverConfig, guiConfig, tempFile, pollingRates, pollingThread = None, None, None, None, None, None
+    stationConfig, serverConfig, guiConfig, tempFile, pollingRates, pollingThread, ipAddresses = None, None, None, None, None, None, None
     if configPath != '':
         # Separates the corresponding settings into the 5 necessary parts
-        stationConfig, serverConfig, guiConfig, tempFile, pollingRates = loadConfig(configPath)
-
+        stationConfig, serverConfig, guiConfig, tempFile, pollingRates, ipAddresses = loadConfig(configPath)
     if pollingRates is not None and pollingRates != {}:
         pollingThread = QtCore.QThread()
         pollWorker = PollingWorker(pollingRates=pollingRates)
@@ -77,7 +76,8 @@ def serverScript() -> None:
                initScript=args.init_script,
                serverConfig=serverConfig,
                stationConfig=stationConfig,
-               pollingThread=pollingThread)
+               pollingThread=pollingThread,
+               ipAddresses=ipAddresses)
     else:
         serverWithGui(port=args.port,
                       addresses=args.listen_at,
@@ -85,7 +85,8 @@ def serverScript() -> None:
                       serverConfig=serverConfig,
                       stationConfig=stationConfig,
                       guiConfig=guiConfig,
-                      pollingThread=pollingThread)
+                      pollingThread=pollingThread,
+                      ipAddresses=ipAddresses)
 
     # Close and delete the temporary files
     if tempFile is not None:

--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -32,7 +32,9 @@ def loadConfig(configPath: str):
     guiConfig = {}  # Individual gui config of each instrument
     fullConfig = {}  # serverConfig + guiConfig + any unfilled fields. Used for creating instruments from the gui
     pollingRates = {}  # Polling rates for each parameter
-    ipAddresses = {} # IP Addresses to send broadcasts to, internal, external, and listening
+    ipAddresses = {} # Dictionary of IP Addresses to send broadcasts to:
+    # externalBroadcast: where to externally send parameter change broadcasts to, formatted like "tcp://address:port"
+    # listeningAddress: additional address to listen to messages received by the server, formatted like "address"
 
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)

--- a/instrumentserver/config.py
+++ b/instrumentserver/config.py
@@ -32,6 +32,7 @@ def loadConfig(configPath: str):
     guiConfig = {}  # Individual gui config of each instrument
     fullConfig = {}  # serverConfig + guiConfig + any unfilled fields. Used for creating instruments from the gui
     pollingRates = {}  # Polling rates for each parameter
+    ipAddresses = {} # IP Addresses to send broadcasts to, internal, external, and listening
 
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)
@@ -73,6 +74,14 @@ def loadConfig(configPath: str):
 
         fullConfig[instrumentName] = {'gui': guiConfig[instrumentName], **configDict, **serverConfig[instrumentName]}
 
+    # Gets all of the broadcasting and listening addresses from the config file
+    if 'networking' in rawConfig:
+        addressDict = rawConfig['networking']
+        if addressDict is not None:
+            for address in addressDict.items():
+                ipAddresses.update({address[0]: address[1]})
+        rawConfig.pop('networking')
+
     # Creating the file like object
     with io.BytesIO() as ioBytesFile:
         yaml.dump(rawConfig, ioBytesFile)
@@ -85,4 +94,4 @@ def loadConfig(configPath: str):
     tempFilePath = tempFile.name
 
     # You need to return the tempFile itself so that the garbage collector doesn't touch it
-    return tempFilePath, serverConfig, fullConfig, tempFile, pollingRates
+    return tempFilePath, serverConfig, fullConfig, tempFile, pollingRates, ipAddresses

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -128,6 +128,7 @@ class StationServer(QtCore.QObject):
 
         self.broadcastPort = self.port + 1
         self.broadcastSocket = None
+        self.externalBroadcastAddr = None
 
         if ipAddresses is not None and 'externalBroadcast' in ipAddresses and ipAddresses.get('externalBroadcast') is not None:
             self.externalBroadcastAddr = ipAddresses.get('externalBroadcast')
@@ -179,7 +180,8 @@ class StationServer(QtCore.QObject):
         self.broadcastSocket.bind(broadcastAddr)
 
         self.externalBroadcastSocket = context.socket(zmq.PUB)
-        self.externalBroadcastSocket.bind(self.externalBroadcastAddr)
+        if self.externalBroadcastAddr is not None:
+            self.externalBroadcastSocket.bind(self.externalBroadcastAddr)
 
         self.serverRunning = True
         if self.initScript not in ['', None]:
@@ -393,7 +395,8 @@ class StationServer(QtCore.QObject):
         :param blueprint: The parameter broadcast blueprint that is being broadcast
         """
         sendBroadcast(self.broadcastSocket, blueprint.name.split('.')[0], blueprint)
-        sendBroadcast(self.externalBroadcastSocket, blueprint.name.split('.')[0], blueprint)
+        if self.externalBroadcastAddr is not None:
+            sendBroadcast(self.externalBroadcastSocket, blueprint.name.split('.')[0], blueprint)
         logger.info(f"Parameter {blueprint.name} has broadcast an update of type: {blueprint.action},"
                      f" with a value: {blueprint.value}.")
 

--- a/instrumentserver/server/core.py
+++ b/instrumentserver/server/core.py
@@ -179,9 +179,12 @@ class StationServer(QtCore.QObject):
         self.broadcastSocket = context.socket(zmq.PUB)
         self.broadcastSocket.bind(broadcastAddr)
 
-        self.externalBroadcastSocket = context.socket(zmq.PUB)
         if self.externalBroadcastAddr is not None:
+            logger.info(f"Also publishing the server at {self.externalBroadcastAddr}")
+            self.externalBroadcastSocket = context.socket(zmq.PUB)
             self.externalBroadcastSocket.bind(self.externalBroadcastAddr)
+        else:
+            logger.info(f"Not broadcasting to external address")
 
         self.serverRunning = True
         if self.initScript not in ['', None]:

--- a/instrumentserver/server/pollingWorker.py
+++ b/instrumentserver/server/pollingWorker.py
@@ -42,7 +42,7 @@ class PollingWorker(QtCore.QThread):
         for param in self.pollingRates:
             timer = QtCore.QTimer()
             timer.timeout.connect(lambda name=param: self.getParamValue(name))
-            timer.start(self.pollingRates.get(param) * 1000)
+            timer.start(int(self.pollingRates.get(param) * 1000))
             timers.append(timer)
 
         self.exec_()


### PR DESCRIPTION
Allows for the addition of a networking field in the config file which contains IP Addresses. These addresses can be used to add more listening addresses and external broadcasting addresses.
Example config file attached
[serverConfig.json](https://github.com/user-attachments/files/16956330/serverConfig.json)
