### PR TITLE
Bugfix: creating a proxy instrument inside of the instrumenserver.

### DIFF
--- a/instrumentserver/client/proxy.py
+++ b/instrumentserver/client/proxy.py
@@ -190,8 +190,7 @@ class ProxyInstrumentModule(ProxyMixin, InstrumentBase):
         # FIXME: This is not consistent with how mixin handles a `None` client. However, this seems like a more
         #  elegant solution than any time we need the client to check to be None, start a new context client instead.
         if cli is None:
-            c = Client(host=host, port=port)
-            self.cli = c
+            self.cli = Client(host=host, port=port)
 
         for mn in self.bp.methods.keys():
             if mn == 'remove_parameter':

--- a/instrumentserver/client/proxy.py
+++ b/instrumentserver/client/proxy.py
@@ -187,6 +187,12 @@ class ProxyInstrumentModule(ProxyMixin, InstrumentBase):
         super().__init__(name, *args, cli=cli, host=host, port=port,
                          remotePath=remotePath, bluePrint=bluePrint, **kwargs)
 
+        # FIXME: This is not consistent with how mixin handles a `None` client. However, this seems like a more
+        #  elegant solution than any time we need the client to check to be None, start a new context client instead.
+        if cli is None:
+            c = Client(host=host, port=port)
+            self.cli = c
+
         for mn in self.bp.methods.keys():
             if mn == 'remove_parameter':
                 def remove_parameter(obj, name: str):


### PR DESCRIPTION
When creating a proxy instrument inside of the instrument server (the proxy instrument points to a different instrument in a separate instrumentserver) the proxy instrument didn't have a client so it was crashing. This PR only creates a new instrument so that it functions correctly.