### PR TITLE
fix: raise descriptive error for empty/comments-only config files (#139)

### DIFF
--- a/src/instrumentserver/config.py
+++ b/src/instrumentserver/config.py
@@ -47,6 +47,17 @@ def loadConfig(
     yaml = ruamel.yaml.YAML()
     rawConfig = yaml.load(configPath)
 
+    # ruamel.yaml returns ``None`` for an empty (or comments-only) config
+    # file. The membership test on the next line would then raise an opaque
+    # ``TypeError: argument of type 'NoneType' is not iterable``, so we
+    # surface a descriptive error that matches the style of the missing-key
+    # message below.
+    if rawConfig is None:
+        raise AttributeError(
+            f"The config file '{configPath}' is empty. "
+            "It needs at least an 'instruments:' section."
+        )
+
     if "instruments" not in rawConfig:
         raise AttributeError(
             "All configurations must be inside the 'instruments' field. "

--- a/test/pytest/test_config.py
+++ b/test/pytest/test_config.py
@@ -178,6 +178,39 @@ my_ins:
 
 
 # ---------------------------------------------------------------------------
+# Error: empty / comments-only config file
+# ---------------------------------------------------------------------------
+
+
+def test_empty_config_raises(tmp_path):
+    """An empty config file must not crash with an opaque TypeError."""
+    cfg = _write_config(tmp_path, "")
+    with pytest.raises(AttributeError, match="empty"):
+        loadConfig(cfg)
+
+
+def test_comments_only_config_raises(tmp_path):
+    """A config file that contains only comments also parses to ``None``."""
+    cfg = _write_config(
+        tmp_path,
+        """\
+# this file is intentionally just comments
+# nothing else
+""",
+    )
+    with pytest.raises(AttributeError, match="empty"):
+        loadConfig(cfg)
+
+
+def test_empty_config_error_mentions_instruments(tmp_path):
+    """The empty-config error should guide the user toward the required key."""
+    cfg = _write_config(tmp_path, "")
+    with pytest.raises(AttributeError) as excinfo:
+        loadConfig(cfg)
+    assert "instruments" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
 # pollingRate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #139

## What was broken

Starting the server with an empty (or comments-only) config file crashed
with an opaque Python error:

```
File "src/instrumentserver/config.py", line 50, in loadConfig
    if "instruments" not in rawConfig:
TypeError: argument of type 'NoneType' is not iterable
```

## Root cause

`ruamel.yaml`'s `yaml.load()` returns `None` when the file is empty
(0 bytes) or contains only YAML comments (no key/value pairs). The
`loadConfig` function in `src/instrumentserver/config.py` then ran
`"instruments" not in rawConfig` immediately on the result, and the
membership test on `None` raised `TypeError`.

The next line of the function already raises a clear `AttributeError`
("All configurations must be inside the 'instruments' field...") when
the key is missing — so a user who simply forgets to add the section
sees a helpful message, but a user with a totally empty or
comments-only file sees a raw Python `TypeError` instead. Both are
missing-key cases at heart, and they should be reported consistently.

## Fix

Added a `rawConfig is None` guard right after `yaml.load()`. When
triggered, it raises an `AttributeError` whose message mirrors the
existing missing-key error and tells the user what to do next:

```
AttributeError: The config file '/path/to/serverConfig.yml' is empty.
It needs at least an 'instruments:' section.
```

## Tests

Three new regression tests in `test/pytest/test_config.py`:

- `test_empty_config_raises` — empty file raises `AttributeError`
  whose message contains "empty".
- `test_comments_only_config_raises` — comments-only file raises the
  same `AttributeError` (yaml also returns `None` for these).
- `test_empty_config_error_mentions_instruments` — the error message
  guides the user toward the required `'instruments:'` key.

All 21 tests in `test_config.py` pass.

## Files changed

- `src/instrumentserver/config.py` — +11 lines, the `None` guard.
- `test/pytest/test_config.py` — +33 lines, three regression tests.